### PR TITLE
Fix bootcamp heading and update CTA links

### DIFF
--- a/bootcamp.html
+++ b/bootcamp.html
@@ -69,7 +69,7 @@
         <div class="container">
           <h1 class="text-white text-4xl md:text-5xl">Agentic Coding Bootcamp: From Generative AI to Autonomous Dev Workflows</h1>
           <p class="text-white text-lg md:text-xl mt-4">A hands-on course teaching you how to build AI agents and modern autonomous development pipelines.</p>
-          <a href="#contact" class="hero-button mt-6">Enroll Now</a>
+          <a href="https://calendly.com/frank-visionzlab/30min" class="hero-button mt-6">Enroll Now</a>
         </div>
       </section>
       <section id="about" class="py-16 bg-white">
@@ -80,7 +80,7 @@
       </section>
       <section id="learn" class="py-16 bg-light">
         <div class="container">
-          <h2 class="section-heading text-center text-3xl md:text-4xl">What You\u2019ll Learn</h2>
+          <h2 class="section-heading text-center text-3xl md:text-4xl">What You'll Learn</h2>
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mt-8">
             <div class="text-center">
               <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto" width="48" height="48" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-3-3v6m3.775-9l1.06 1.06m-9.17 0l1.06-1.06M5 12H4m0 0v.01M19 12h1m0 0v.01M5.98 19.017l1.06-1.061m9.884 0l1.06 1.06"/></svg>
@@ -132,7 +132,7 @@
       <section id="contact" class="py-16 bg-white">
         <div class="container">
           <h2 class="section-heading text-center text-3xl md:text-4xl">Contact Us</h2>
-          <form id="contact-form" class="contact-form" action="#" method="POST" data-track="Bootcamp Contact Form">
+          <form id="contact-form" class="contact-form" action="https://api.architect.solutions/contact" method="POST" data-track="Bootcamp Contact Form">
             <div class="form-group">
               <label for="name">Name</label>
               <input type="text" id="name" name="name" class="form-control" required aria-required="true" />

--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
                 class="flex flex-row sm:flex-row gap-4 mt-8 animate-on-scroll animate-delay-2"
               >
                 <a
-                  href="#contact"
+                  href="https://calendly.com/frank-visionzlab/30min"
                   class="btn btn-secondary btn-lg"
                   data-track="Hero CTA"
                   >Book Your Free Consultation</a
@@ -993,7 +993,7 @@
               help your organization implement agentic coding and MCPs.
             </p>
             <a
-              href="#calendly-container"
+              href="https://calendly.com/frank-visionzlab/30min"
               class="btn btn-secondary btn-lg"
               data-schedule-button
               data-track="Main CTA"

--- a/llm.txt
+++ b/llm.txt
@@ -1,0 +1,3 @@
+# LLM Policy for Architect Solutions
+User-agent: *
+Allow: /

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://architect.solutions/bootcamp</loc>
+    <lastmod>2025-04-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://architect.solutions/privacy-policy</loc>
     <lastmod>2025-04-01</lastmod>
     <changefreq>yearly</changefreq>


### PR DESCRIPTION
## Summary
- correct bootcamp section heading
- point bootcamp hero button to Calendly
- set bootcamp form action to API endpoint
- update CTA links on main landing page
- include bootcamp page in sitemap
- add llm.txt policy file

## Testing
- `python3 architect_solutions_logo_generator.py` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6854a4d6774c832dba7f866bb568454f