### PR TITLE
Add bootcamp PDF download link

### DIFF
--- a/bootcamp.html
+++ b/bootcamp.html
@@ -69,6 +69,7 @@
           <p class="text-white text-lg md:text-xl mt-4 animate-on-scroll animate-delay-1">From LLM Fundamentals to Production-Ready AI Agents with MCPs, RAG, and Modern IDE Integration</p>
           <p class="text-white text-lg md:text-xl animate-on-scroll animate-delay-2">Build autonomous coding workflows that are both powerful AND safe</p>
           <a href="https://calendly.com/frank-visionzlab/30min" class="hero-button mt-6 animate-on-scroll animate-delay-3">Enroll Now</a>
+          <a href="assets/Agentic%20Coding%20Bootcamp.pdf" download class="hero-button mt-6 animate-on-scroll animate-delay-3">Download Overview (PDF)</a>
         </div>
       </section>
       <section id="about" class="py-24 bg-white">


### PR DESCRIPTION
## Summary
- add a download link for the bootcamp overview PDF on the bootcamp page

## Testing
- `cat index.html | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6856f25e699c832d9ea4e7194c3301dd