### PR TITLE
Add padding to blog layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -12,6 +12,10 @@ body {
   overflow-x: hidden;
 }
 
+.blog-layout {
+  padding: 6rem 1rem 4rem;
+}
+
 /* Header & Navigation */
 header {
   position: fixed;

--- a/blog.html
+++ b/blog.html
@@ -77,7 +77,7 @@
         </nav>
       </div>
     </header>
-    <main id="main-content">
+    <main id="main-content" class="blog-layout">
       <section class="blog-hero">
         <div class="container text-center py-16">
           <h1 class="text-4xl md:text-5xl font-bold animate-on-scroll">

--- a/blog/agentic-ai-cognitive-work.html
+++ b/blog/agentic-ai-cognitive-work.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>Agentic AI and the New Face of Cognitive Work in Software Development</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/ai-agile-detailed-planning.html
+++ b/blog/ai-agile-detailed-planning.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>AI, Agile, and the Return of Detailed Planning: A New Balance for Leaders</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/differentiate-from-vibe-coders.html
+++ b/blog/differentiate-from-vibe-coders.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>How to Differentiate Yourself from Vibe Coders</h1>
         <p class="meta">Frank Goortani • May 13, 2025</p>

--- a/blog/from-coders-to-cognitive-architects.html
+++ b/blog/from-coders-to-cognitive-architects.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>From Coders to Cognitive Architects: Simulating 5 Years of Autonomous Coding Agents</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/from-tools-to-impact.html
+++ b/blog/from-tools-to-impact.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>From Tools to Impact: Translating AI Stack Choices into Business Outcomes</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/generative-ai-startups-defensive-moats.html
+++ b/blog/generative-ai-startups-defensive-moats.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>How Generative-AI Start-ups Build — and Keep — Defensive Moats</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/how-lean-teams-can-build-generative-ai-mvps.html
+++ b/blog/how-lean-teams-can-build-generative-ai-mvps.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>How Lean Teams Can Build Generative AI MVPs — And Punch Far Above Their Weight</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/loka-protocol-ethical-ai-governance.html
+++ b/blog/loka-protocol-ethical-ai-governance.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>The LOKA Protocol: A Game-Changer for Ethical AI Agent Governance</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/sse-is-the-king.html
+++ b/blog/sse-is-the-king.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>SSE Is the King: How LLM Streaming Is Changing the Software Architecture Focus</h1>
         <p class="meta">Frank Goortani</p>

--- a/blog/translating-ai-architecture-into-c-suite-roi.html
+++ b/blog/translating-ai-architecture-into-c-suite-roi.html
@@ -86,7 +86,7 @@
         </nav>
       </div>
     </header>
-    <main class="container">
+    <main class="container blog-layout">
       <article class="animate-on-scroll">
         <h1>Translating AI Architecture Into C-Suite ROI: A Practical 5-Step Guide</h1>
         <p class="meta">Frank Goortani</p>


### PR DESCRIPTION
## Summary
- add reusable `.blog-layout` class with top and bottom spacing
- apply `.blog-layout` to all blog pages so content sits away from header and footer

## Testing
- `python3 architect_solutions_logo_generator.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy matplotlib` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689796c89ec8832db9188176a5600fed